### PR TITLE
Update Ruthenia UHV

### DIFF
--- a/Assets/Python/HistoricalVictory.py
+++ b/Assets/Python/HistoricalVictory.py
@@ -572,11 +572,11 @@ dGoals = {
 		),
 	),
 	iRus: (
-		ReligionPopulationCount(iOrthodoxy, 30, by=1200),
 		DefeatedUnits(civs(iBarbarian), 25, by=1250),
+		TradeRouteCommerce(800, by=1300),
 		All(
-			ResourceCount((iFur, 4), (iSalt, 3)),
-			TradeGold(200),
+			ResourceCount((sum(lHappinessResources).named(HAPPINESS_RESOURCES), 6), (iSalt, 3)),
+			TradeGold(600),
 			by=1450,
 		),
 	),


### PR DESCRIPTION
Defeated barbarians goal remains unchanged.
30 Orthodox population by 1200 goal changed to 800 trade route commerce by 1300. For 3rd goal, 4 furs changed to 6 happiness resources, and 3 salt as before. Trade goal quantity tripled, as you can obtain trade gold from tech trading, receiving gifts, etc

The purpose behind these changes is to encourage the building of the Ruthenian UB, and increase the methods by which a UHV can be achieved.